### PR TITLE
MCMC-based backward sampling

### DIFF
--- a/experiments/pendulum/linear/io_csmc_sysid.jl
+++ b/experiments/pendulum/linear/io_csmc_sysid.jl
@@ -99,7 +99,7 @@ nb_csmc_moves = 1
 
 nb_iter = 25
 opt_state = Flux.setup(Flux.Optimise.Adam(1e-3), learner_loop)
-batch_size = 64
+batch_size = 16
 
 Flux.reset!(learner_loop.ctl)
 state_struct, param_struct = smc_with_ibis_marginal_dynamics(
@@ -124,6 +124,8 @@ reference = IBISReference(
     param_struct.log_likelihoods[:, :, idx]
 )
 
+backward_sample = true
+
 learner_loop, _ = markovian_score_climbing_with_ibis_marginal_dynamics(
     nb_iter,
     opt_state,
@@ -140,7 +142,7 @@ learner_loop, _ = markovian_score_climbing_with_ibis_marginal_dynamics(
     tempering,
     reference,
     nb_csmc_moves,
-    true,
+    backward_sample,
     param_proposal,
     nb_ibis_moves,
     true


### PR DESCRIPTION
Implemented backward sampling with $\mathcal{O}(NM^2T^2)$ cost for $N$ backward samples.

---
# References
1. Hai-Dang Dau and Nicolas Chopin (2023). On backward smoothing algorithms. The Annals of Statistics.
2. Nicolas Chopin (2020). Particles. [Github](https://github.com/nchopin/particles/blob/841cf363b3f1dee0faa77f6a0349ace3477917ab/particles/smoothing.py#L313).